### PR TITLE
Update Tooltip.lua

### DIFF
--- a/ElvUI/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Modules/Tooltip/Tooltip.lua
@@ -521,20 +521,17 @@ function TT:GameTooltip_OnTooltipSetItem(tt)
 	if self.db.itemCount == "BAGS_ONLY" then
 		right = format("|cFFCA3C3C%s|r %d", L["Count"], num)
 	elseif self.db.itemCount == "BANK_ONLY" then
-		bankCount = format("|cFFCA3C3C%s|r %d", L["Bank"], (numall - num))
+		right = format("|cFFCA3C3C%s|r %d", L["Bank"], (numall - num))
 	elseif self.db.itemCount == "BOTH" then
 		right = format("|cFFCA3C3C%s|r %d", L["Count"], num)
 		bankCount = format("|cFFCA3C3C%s|r %d", L["Bank"], (numall - num))
+		right = right .. " " .. bankCount
 	end
 
 	if left or right then
-		tt:AddLine(" ")
 		tt:AddDoubleLine(left or " ", right or " ")
 	end
-	if bankCount then
-		tt:AddDoubleLine(" ", bankCount)
-	end
-
+	
 	tt.itemCleared = true
 end
 


### PR DESCRIPTION
Instead of showing in the Tooltip of an item, when selected for showing BOTH Guild and Bags count, the two counts in different lines, use only one. 
https://i.imgur.com/HmSvuwP.png
This way you save up space. Usually you have more than one addon that adds lines to the tooltip and creating one additional line just for a Bank count is not ideal.