### PR TITLE
Add extra info to tooltips

### DIFF
--- a/ElvUI/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Modules/Tooltip/Tooltip.lua
@@ -517,10 +517,10 @@ function TT:GameTooltip_OnTooltipSetItem(tt)
 	if self.db.itemDetails == "ID_ONLY" then
 		itemID = format("|cFFCA3C3C%s|r %d", ID, tonumber(match(link, ":(%d+)")))
 	elseif self.db.itemDetails == "ILVL_ONLY" then
-		itemLvl = format("|cFFCA3C3C%s|r %d", "iLvl", select(4, GetItemInfo(link)))
+		itemLvl = format("|cFFCA3C3C%s|r %d", "iLvl", select(4, GetItemInfo(link)) or 0)
 	elseif self.db.itemDetails == "BOTH" then
 		itemID = format("|cFFCA3C3C%s|r %d", ID, tonumber(match(link, ":(%d+)")))
-		itemLvl = format("|cFFCA3C3C%s|r %d", "iLvl", select(4, GetItemInfo(link)))
+		itemLvl = format("|cFFCA3C3C%s|r %d", "iLvl", select(4, GetItemInfo(link)) or 0)
 	end
 
 	if self.db.itemCount == "BAGS_ONLY" then

--- a/ElvUI/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Modules/Tooltip/Tooltip.lua
@@ -538,7 +538,7 @@ function TT:GameTooltip_OnTooltipSetItem(tt)
 	end
 
 	if count or bankCount then
-		if not itemID and not itemLvl then 
+		if not itemID and not itemLvl then
 			tt:AddLine(" ")
 		end
 		tt:AddDoubleLine(count or " ", bankCount or " ")

--- a/ElvUI/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Modules/Tooltip/Tooltip.lua
@@ -512,27 +512,36 @@ function TT:GameTooltip_OnTooltipSetItem(tt)
 
 	local num = GetItemCount(link)
 	local numall = GetItemCount(link, true)
-	local left, right, bankCount
+	local itemID, itemLvl, count, bankCount
 
-	if self.db.spellID then
-		left = format("|cFFCA3C3C%s|r %d", ID, tonumber(match(link, ":(%d+)")))
+	if self.db.itemDetails == "ID_ONLY" then
+		itemID = format("|cFFCA3C3C%s|r %d", ID, tonumber(match(link, ":(%d+)")))
+	elseif self.db.itemDetails == "ILVL_ONLY" then
+		itemLvl = format("|cFFCA3C3C%s|r %d", "iLvl", select(4, GetItemInfo(link)))
+	elseif self.db.itemDetails == "BOTH" then
+		itemID = format("|cFFCA3C3C%s|r %d", ID, tonumber(match(link, ":(%d+)")))
+		itemLvl = format("|cFFCA3C3C%s|r %d", "iLvl", select(4, GetItemInfo(link)))
 	end
 
 	if self.db.itemCount == "BAGS_ONLY" then
-		right = format("|cFFCA3C3C%s|r %d", L["Count"], num)
+		count = format("|cFFCA3C3C%s|r %d", L["Count"], num)
 	elseif self.db.itemCount == "BANK_ONLY" then
 		bankCount = format("|cFFCA3C3C%s|r %d", L["Bank"], (numall - num))
 	elseif self.db.itemCount == "BOTH" then
-		right = format("|cFFCA3C3C%s|r %d", L["Count"], num)
+		count = format("|cFFCA3C3C%s|r %d", L["Count"], num)
 		bankCount = format("|cFFCA3C3C%s|r %d", L["Bank"], (numall - num))
 	end
 
-	if left or right then
+	if itemID or itemLvl then
 		tt:AddLine(" ")
-		tt:AddDoubleLine(left or " ", right or " ")
+		tt:AddDoubleLine(itemID or " ", itemLvl or " ")
 	end
-	if bankCount then
-		tt:AddDoubleLine(" ", bankCount)
+
+	if count or bankCount then
+		if not itemID and not itemLvl then 
+			tt:AddLine(" ")
+		end
+		tt:AddDoubleLine(count or " ", bankCount or " ")
 	end
 
 	tt.itemCleared = true
@@ -684,8 +693,6 @@ function TT:Initialize()
 	self:SecureHook(BNToastFrame, "SetPoint", "RepositionBNET")
 
 	if not E.private.tooltip.enable then return end
-
-	SetCVar("showItemLevel", 1)
 
 	GameTooltip.StatusBar = GameTooltipStatusBar
 	GameTooltip.StatusBar:Height(self.db.healthBar.height)

--- a/ElvUI/Settings/Profile.lua
+++ b/ElvUI/Settings/Profile.lua
@@ -1151,6 +1151,7 @@ P.tooltip = {
 	targetInfo = true,
 	playerTitles = true,
 	guildRanks = true,
+	itemDetails = "ID_ONLY",
 	itemCount = "BAGS_ONLY",
 	spellID = true,
 	npcID = true,

--- a/ElvUI_OptionsUI/Locales/enUS.lua
+++ b/ElvUI_OptionsUI/Locales/enUS.lua
@@ -612,6 +612,7 @@ L["Item Count Font"] = true
 L["Item Count"] = true
 L["Item Level Threshold"] = true
 L["Item Level"] = true
+L["Item ID"] = true
 L["JustifyH"] = true
 L["Key Down"] = true
 L["Keybind Mode"] = true

--- a/ElvUI_OptionsUI/Tooltip.lua
+++ b/ElvUI_OptionsUI/Tooltip.lua
@@ -94,19 +94,19 @@ E.Options.args.tooltip = {
 					order = 10,
 					type = "toggle",
 					name = L["Spell IDs"],
-					desc = L["Display the spell when mousing over a spell."]
+					desc = L["Display the spell id when mousing over a spell tooltip."]
 				},
 				npcID = {
 					order = 11,
 					type = "toggle",
 					name = L["NPC IDs"],
-					desc = L["Display the npc ID when mousing over a npc tooltip."],
+					desc = L["Display the npc id when mousing over a npc."],
 				},
 				itemDetails = {
 					order = 12,
 					type = "select",
 					name = L["Item Details"],
-					desc = L["Display Item ID or Item Level"],
+					desc = L["Display the item id and/or item level."],
 					values = {
 						["ID_ONLY"] = L["Item ID"],
 						["ILVL_ONLY"] = L["Item Level"],

--- a/ElvUI_OptionsUI/Tooltip.lua
+++ b/ElvUI_OptionsUI/Tooltip.lua
@@ -93,8 +93,8 @@ E.Options.args.tooltip = {
 				spellID = {
 					order = 10,
 					type = "toggle",
-					name = L["Spell/Item IDs"],
-					desc = L["Display the spell or item ID when mousing over a spell or item tooltip."]
+					name = L["Spell IDs"],
+					desc = L["Display the spell when mousing over a spell."]
 				},
 				npcID = {
 					order = 11,
@@ -102,8 +102,20 @@ E.Options.args.tooltip = {
 					name = L["NPC IDs"],
 					desc = L["Display the npc ID when mousing over a npc tooltip."],
 				},
-				itemCount = {
+				itemDetails = {
 					order = 12,
+					type = "select",
+					name = L["Item Details"],
+					desc = L["Display Item ID or Item Level"],
+					values = {
+						["ID_ONLY"] = L["Item ID"],
+						["ILVL_ONLY"] = L["Item Level"],
+						["BOTH"] = L["Both"],
+						["NONE"] = L["NONE"]
+					}
+				},
+				itemCount = {
+					order = 13,
 					type = "select",
 					name = L["Item Count"],
 					desc = L["Display how many of a certain item you have in your possession."],
@@ -115,7 +127,7 @@ E.Options.args.tooltip = {
 					}
 				},
 				colorAlpha = {
-					order = 13,
+					order = 14,
 					type = "range",
 					name = L["OPACITY"],
 					isPercent = true,


### PR DESCRIPTION
Adds iLvl and Item ID to tooltips in the same style as Count and Bank Count
![image](https://user-images.githubusercontent.com/26512802/114692521-cdd13200-9d6c-11eb-9fac-122395e94831.png)
