### PR TITLE
Don't ClassColor names less than 3 characters

### DIFF
--- a/ElvUI/Modules/Chat/Chat.lua
+++ b/ElvUI/Modules/Chat/Chat.lua
@@ -1433,7 +1433,7 @@ function CH:CheckKeyword(message, author)
 				end
 			end
 
-			if self.db.classColorMentionsChat then
+			if self.db.classColorMentionsChat and string.len(word) < 3 then
 				tempWord = gsub(word, "^[%s%p]-([^%s%p]+)([%-]?[^%s%p]-)[%s%p]*$", "%1%2")
 				lowerCaseWord = strlower(tempWord)
 

--- a/ElvUI/Modules/Misc/ChatBubbles.lua
+++ b/ElvUI/Modules/Misc/ChatBubbles.lua
@@ -44,22 +44,24 @@ function M:UpdateBubbleBorder()
 			local classColorTable, lowerCaseWord, isFirstWord, rebuiltString, tempWord, wordMatch, classMatch
 
 			for word in gmatch(text, "%s-%S+%s*") do
-				tempWord = gsub(word, "^[%s%p]-([^%s%p]+)([%-]?[^%s%p]-)[%s%p]*$", "%1%2")
-				lowerCaseWord = lower(tempWord)
+				if string.len(word) < 3 then
+					tempWord = gsub(word, "^[%s%p]-([^%s%p]+)([%-]?[^%s%p]-)[%s%p]*$", "%1%2")
+					lowerCaseWord = lower(tempWord)
 
-				classMatch = CH.ClassNames[lowerCaseWord]
-				wordMatch = classMatch and lowerCaseWord
+					classMatch = CH.ClassNames[lowerCaseWord]
+					wordMatch = classMatch and lowerCaseWord
 
-				if wordMatch and not E.global.chat.classColorMentionExcludedNames[wordMatch] then
-					classColorTable = CUSTOM_CLASS_COLORS and CUSTOM_CLASS_COLORS[classMatch] or RAID_CLASS_COLORS[classMatch]
-					word = gsub(word, gsub(tempWord, "%-", "%%-"), format("\124cff%.2x%.2x%.2x%s\124r", classColorTable.r*255, classColorTable.g*255, classColorTable.b*255, tempWord))
-				end
+					if wordMatch and not E.global.chat.classColorMentionExcludedNames[wordMatch] then
+						classColorTable = CUSTOM_CLASS_COLORS and CUSTOM_CLASS_COLORS[classMatch] or RAID_CLASS_COLORS[classMatch]
+						word = gsub(word, gsub(tempWord, "%-", "%%-"), format("\124cff%.2x%.2x%.2x%s\124r", classColorTable.r*255, classColorTable.g*255, classColorTable.b*255, tempWord))
+					end
 
-				if not isFirstWord then
-					rebuiltString = word
-					isFirstWord = true
-				else
-					rebuiltString = format("%s%s", rebuiltString, word)
+					if not isFirstWord then
+						rebuiltString = word
+						isFirstWord = true
+					else
+						rebuiltString = format("%s%s", rebuiltString, word)
+					end
 				end
 			end
 


### PR DESCRIPTION
I've noticed a growing trend of people creating characters with names only two characters long.
This commit prevents words like he, it, to, my, no, etc. being coloured as the class of the player that used them.