### PR TITLE
Change chatbubble strata to BACKGROUND

### DIFF
--- a/ElvUI/Modules/Misc/ChatBubbles.lua
+++ b/ElvUI/Modules/Misc/ChatBubbles.lua
@@ -203,7 +203,7 @@ function M:SkinBubble(frame)
 	end
 
 	frame:HookScript("OnShow", M.UpdateBubbleBorder)
-	frame:SetFrameStrata("DIALOG")
+	frame:SetFrameStrata("BACKGROUND")
 	M.UpdateBubbleBorder(frame)
 
 	frame.isSkinnedElvUI = true


### PR DESCRIPTION
Fixes overlap with addons (like raidframes, for example)