### PR TITLE
Add an option to toggle custom health color for NPCs.

### DIFF
--- a/ElvUI/Modules/UnitFrames/Elements/Health.lua
+++ b/ElvUI/Modules/UnitFrames/Elements/Health.lua
@@ -245,7 +245,7 @@ function UF:PostUpdateHealthColor(unit, r, g, b)
 		self:SetStatusBarColor(newr, newg, newb)
 	end
 	
-	if colors.customNPChealth and not UnitIsPlayer(unit) and not UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit) then
+	if colors.customNPChealth and not UnitIsPlayer(unit) and not (UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit)) then
 		local cur, max = self.cur or 1, self.max or 100
 		newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, colors.npc_health_pick.r, colors.npc_health_pick.g, colors.npc_health_pick.b)
 		self:SetStatusBarColor(newr, newg, newb)

--- a/ElvUI/Modules/UnitFrames/Elements/Health.lua
+++ b/ElvUI/Modules/UnitFrames/Elements/Health.lua
@@ -240,8 +240,12 @@ function UF:PostUpdateHealthColor(unit, r, g, b)
 			cur = parent.forcedHealth or cur
 			max = (cur > max and cur * 2) or max
 		end
-
-		newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, r, g, b)
+		
+		if colors.customNPChealth and not UnitIsPlayer(unit) then
+			newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, colors.npc_health_pick.r, colors.npc_health_pick.g, colors.npc_health_pick.b)
+		else
+			newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, r, g, b)
+		end
 		self:SetStatusBarColor(newr, newg, newb)
 	end
 

--- a/ElvUI/Modules/UnitFrames/Elements/Health.lua
+++ b/ElvUI/Modules/UnitFrames/Elements/Health.lua
@@ -246,8 +246,11 @@ function UF:PostUpdateHealthColor(unit, r, g, b)
 	end
 	
 	if colors.customNPChealth and not UnitIsPlayer(unit) and not (UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit)) then
-		local cur, max = self.cur or 1, self.max or 100
-		newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, colors.npc_health_pick.r, colors.npc_health_pick.g, colors.npc_health_pick.b)
+		newr, newg, newb = colors.npc_health_pick.r, colors.npc_health_pick.g, colors.npc_health_pick.b
+		if colors.colorhealthbyvalue then
+			local cur, max = self.cur or 1, self.max or 100
+			newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, colors.npc_health_pick.r, colors.npc_health_pick.g, colors.npc_health_pick.b)
+		end
 		self:SetStatusBarColor(newr, newg, newb)
 	end
 

--- a/ElvUI/Modules/UnitFrames/Elements/Health.lua
+++ b/ElvUI/Modules/UnitFrames/Elements/Health.lua
@@ -240,12 +240,14 @@ function UF:PostUpdateHealthColor(unit, r, g, b)
 			cur = parent.forcedHealth or cur
 			max = (cur > max and cur * 2) or max
 		end
-		
-		if colors.customNPChealth and not UnitIsPlayer(unit) then
-			newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, colors.npc_health_pick.r, colors.npc_health_pick.g, colors.npc_health_pick.b)
-		else
-			newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, r, g, b)
-		end
+
+		newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, r, g, b)
+		self:SetStatusBarColor(newr, newg, newb)
+	end
+	
+	if colors.customNPChealth and not UnitIsPlayer(unit) and not UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit) then
+		local cur, max = self.cur or 1, self.max or 100
+		newr, newg, newb = ElvUF:ColorGradient(cur, max, 1, 0, 0, 1, 1, 0, colors.npc_health_pick.r, colors.npc_health_pick.g, colors.npc_health_pick.b)
 		self:SetStatusBarColor(newr, newg, newb)
 	end
 

--- a/ElvUI/Settings/Profile.lua
+++ b/ElvUI/Settings/Profile.lua
@@ -1304,6 +1304,7 @@ P.unitframe = {
 		castClassColor = false,
 		castReactionColor = false,
 		health = {r = 0.31, g = 0.31, b = 0.31},
+		npc_health_pick = {r = 0, g = 0.85, b = 0},
 		health_backdrop = {r = 0.8, g = 0.01, b = 0.01},
 		health_backdrop_dead = {r = 0.8, g = 0.01, b = 0.01},
 		castbar_backdrop = {r = 0.5, g = 0.5, b = 0.5},

--- a/ElvUI_OptionsUI/UnitFrames.lua
+++ b/ElvUI_OptionsUI/UnitFrames.lua
@@ -2909,15 +2909,15 @@ E.Options.args.unitframe = {
 								customNPChealth = {
 									order = 8,
 									type = "toggle",
-									name = L["Custom NPC Healthbar"],
-									desc = L["Toggle a different healthbar for NPCs."],
+									name = L["Custom NPC Health"],
+									desc = L["Use a different healthbar color for NPCs."],
 									get = function(info) return E.db.unitframe.colors[info[#info]] end,
 									set = function(info, value) E.db.unitframe.colors[info[#info]] = value UF:Update_AllFrames() end
 								},
 								npc_health_pick = {
 									order = 9,
 									type = "color",
-									name = L["NPC Healthbar"],
+									name = L["NPC Health"],
 									disabled = function() return not E.db.unitframe.colors.customNPChealth end
 								},
 								spacer2 = {

--- a/ElvUI_OptionsUI/UnitFrames.lua
+++ b/ElvUI_OptionsUI/UnitFrames.lua
@@ -2906,19 +2906,19 @@ E.Options.args.unitframe = {
 									name = " ",
 									width = "full"
 								},
-								customhealthbackdrop = {
+								customNPChealth = {
 									order = 8,
 									type = "toggle",
-									name = L["Custom Backdrop"],
-									desc = L["Use the custom backdrop color instead of a multiple of the main color."],
+									name = L["Custom NPC Healthbar"],
+									desc = L["Toggle a different healthbar for NPCs."],
 									get = function(info) return E.db.unitframe.colors[info[#info]] end,
 									set = function(info, value) E.db.unitframe.colors[info[#info]] = value UF:Update_AllFrames() end
 								},
-								health_backdrop = {
+								npc_health_pick = {
 									order = 9,
 									type = "color",
-									name = L["Health Backdrop"],
-									disabled = function() return not E.db.unitframe.colors.customhealthbackdrop end
+									name = L["NPC Healthbar"],
+									disabled = function() return not E.db.unitframe.colors.customNPChealth end
 								},
 								spacer2 = {
 									order = 10,
@@ -2926,20 +2926,19 @@ E.Options.args.unitframe = {
 									name = " ",
 									width = "full"
 								},
-								useDeadBackdrop = {
+								customhealthbackdrop = {
 									order = 11,
 									type = "toggle",
-									name = L["Use Dead Backdrop"],
+									name = L["Custom Backdrop"],
+									desc = L["Use the custom backdrop color instead of a multiple of the main color."],
 									get = function(info) return E.db.unitframe.colors[info[#info]] end,
 									set = function(info, value) E.db.unitframe.colors[info[#info]] = value UF:Update_AllFrames() end
 								},
-								health_backdrop_dead = {
+								health_backdrop = {
 									order = 12,
 									type = "color",
-									name = L["Custom Dead Backdrop"],
-									desc = L["Use this backdrop color for units that are dead or ghosts."],
-									customWidth = 250,
-									disabled = function() return not E.db.unitframe.colors.useDeadBackdrop end
+									name = L["Health Backdrop"],
+									disabled = function() return not E.db.unitframe.colors.customhealthbackdrop end
 								},
 								spacer3 = {
 									order = 13,
@@ -2947,8 +2946,29 @@ E.Options.args.unitframe = {
 									name = " ",
 									width = "full"
 								},
-								classbackdrop = {
+								useDeadBackdrop = {
 									order = 14,
+									type = "toggle",
+									name = L["Use Dead Backdrop"],
+									get = function(info) return E.db.unitframe.colors[info[#info]] end,
+									set = function(info, value) E.db.unitframe.colors[info[#info]] = value UF:Update_AllFrames() end
+								},
+								health_backdrop_dead = {
+									order = 15,
+									type = "color",
+									name = L["Custom Dead Backdrop"],
+									desc = L["Use this backdrop color for units that are dead or ghosts."],
+									customWidth = 250,
+									disabled = function() return not E.db.unitframe.colors.useDeadBackdrop end
+								},
+								spacer4 = {
+									order = 16,
+									type = "description",
+									name = " ",
+									width = "full"
+								},
+								classbackdrop = {
+									order = 17,
 									type = "toggle",
 									name = L["Class Backdrop"],
 									desc = L["Color the health backdrop by class or reaction."],
@@ -2957,7 +2977,7 @@ E.Options.args.unitframe = {
 									disabled = function() return E.db.unitframe.colors.customhealthbackdrop end
 								},
 								healthMultiplier = {
-									order = 15,
+									order = 18,
 									type = "range",
 									name = L["Health Backdrop Multiplier"],
 									min = 0, softMax = 0.75, max = 1, step = .01,
@@ -2965,24 +2985,24 @@ E.Options.args.unitframe = {
 									set = function(info, value) E.db.unitframe.colors[info[#info]] = value UF:Update_AllFrames() end,
 									disabled = function() return E.db.unitframe.colors.customhealthbackdrop end
 								},
-								spacer4 = {
-									order = 16,
+								spacer5 = {
+									order = 19,
 									type = "description",
 									name = " ",
 									width = "full"
 								},
 								tapped = {
-									order = 17,
+									order = 20,
 									type = "color",
 									name = L["Tapped"]
 								},
 								health = {
-									order = 18,
+									order = 21,
 									type = "color",
 									name = L["HEALTH"]
 								},
 								disconnected = {
-									order = 19,
+									order = 22,
 									type = "color",
 									name = L["Disconnected"]
 								}


### PR DESCRIPTION
Currently NPC healthbars are colored either by their reaction if class coloring is enabled or if it's disabled then same color as every other healthbar. This will allow to, for example, enable class colors for players, but NPCs can have a player selected color.