### PR TITLE
Fix hotkey range, apply default behavior without hiding when available

### DIFF
--- a/ElvUI/Libraries/LibActionButton-1.0/LibActionButton-1.0.lua
+++ b/ElvUI/Libraries/LibActionButton-1.0/LibActionButton-1.0.lua
@@ -838,29 +838,39 @@ function UpdateGrid(self)
 end
 
 function UpdateRange(self, force) -- Sezz: moved from OnUpdate
-	local inRange = self:IsInRange()
-	local oldRange = self.outOfRange
-	self.outOfRange = (inRange == false)
-	if force or (oldRange ~= self.outOfRange) then
-		if self.config.outOfRangeColoring == "button" then
-			UpdateUsable(self)
-		elseif self.config.outOfRangeColoring == "hotkey" then
-			local hotkey = self.hotkey
-			if hotkey:GetText() == RANGE_INDICATOR then
-				if inRange == false then
-					hotkey:Show()
-				else
-					hotkey:Hide()
-				end
-			end
+  local inRange = self:IsInRange()
 
-			if inRange == false then
-				hotkey:SetVertexColor(unpack(self.config.colors.range))
-			else
-				hotkey:SetVertexColor(unpack(self.config.colors.usable))
-			end
+  local oldRange = self.outOfRange
+  local canAttack = self.canAttack
+
+  self.outOfRange = (inRange == false)
+  self.canAttack = (inRange ~= nil)
+
+  if force or (oldRange ~= self.outOfRange) or (canAttack ~= self.canAttack) then
+	if self.config.outOfRangeColoring == "hotkey" then
+	  local hotkey = self.hotkey
+	  if hotkey:GetText() == RANGE_INDICATOR then
+		if self.canAttack then
+		  hotkey:Show()
+		else
+		  hotkey:Hide()
 		end
+	  end
 	end
+  end
+
+  if force or (oldRange ~= self.outOfRange) then
+	if self.config.outOfRangeColoring == "button" then
+	  UpdateUsable(self)
+	elseif self.config.outOfRangeColoring == "hotkey" then
+	  local hotkey = self.hotkey
+	  if self.outOfRange then
+		hotkey:SetVertexColor(unpack(self.config.colors.range))
+	  else
+		hotkey:SetVertexColor(unpack(self.config.colors.usable))
+	  end
+	end
+  end
 end
 
 -----------------------------------------------------------
@@ -1127,20 +1137,25 @@ function UpdateTooltip(self)
 end
 
 function UpdateHotkeys(self)
-	local key = self:GetHotkey()
-	if not key or key == "" or self.config.hideElements.hotkey then
-		self.hotkey:SetText(RANGE_INDICATOR)
-		self.hotkey:SetPoint("TOPRIGHT", 0, -3);
-		self.hotkey:Hide()
+  local key = self:GetHotkey()
+  if not key or key == "" or self.config.hideElements.hotkey then
+	self.hotkey:SetText(RANGE_INDICATOR)
+	self.hotkey:SetPoint("TOPRIGHT", 0, -3);
+	local inRange = self:IsInRange()
+	if inRange ~= nil then
+	  self.hotkey:Show();
 	else
-		self.hotkey:SetText(key)
-		self.hotkey:SetPoint("TOPRIGHT", 0, -3);
-		self.hotkey:Show()
+	  self.hotkey:Hide()
 	end
+  else
+	self.hotkey:SetText(key)
+	self.hotkey:SetPoint("TOPRIGHT", 0, -3);
+	self.hotkey:Show()
+  end
 
-	if self.postKeybind then
-		self.postKeybind(nil, self)
-	end
+  if self.postKeybind then
+	self.postKeybind(nil, self)
+  end
 end
 
 function UpdateRangeTimer()

--- a/ElvUI/Libraries/LibActionButton-1.0/LibActionButton-1.0.lua
+++ b/ElvUI/Libraries/LibActionButton-1.0/LibActionButton-1.0.lua
@@ -838,39 +838,39 @@ function UpdateGrid(self)
 end
 
 function UpdateRange(self, force) -- Sezz: moved from OnUpdate
-  local inRange = self:IsInRange()
+	local inRange = self:IsInRange()
 
-  local oldRange = self.outOfRange
-  local canAttack = self.canAttack
+	local oldRange = self.outOfRange
+	local canAttack = self.canAttack
 
-  self.outOfRange = (inRange == false)
-  self.canAttack = (inRange ~= nil)
+	self.outOfRange = (inRange == false)
+	self.canAttack = (inRange ~= nil)
 
-  if force or (oldRange ~= self.outOfRange) or (canAttack ~= self.canAttack) then
-	if self.config.outOfRangeColoring == "hotkey" then
-	  local hotkey = self.hotkey
-	  if hotkey:GetText() == RANGE_INDICATOR then
-		if self.canAttack then
-		  hotkey:Show()
-		else
-		  hotkey:Hide()
+	if force or (oldRange ~= self.outOfRange) or (canAttack ~= self.canAttack) then
+		if self.config.outOfRangeColoring == "hotkey" then
+			local hotkey = self.hotkey
+			if hotkey:GetText() == RANGE_INDICATOR then
+				if self.canAttack then
+					hotkey:Show()
+				else
+					hotkey:Hide()
+				end
+			end
 		end
-	  end
 	end
-  end
 
-  if force or (oldRange ~= self.outOfRange) then
-	if self.config.outOfRangeColoring == "button" then
-	  UpdateUsable(self)
-	elseif self.config.outOfRangeColoring == "hotkey" then
-	  local hotkey = self.hotkey
-	  if self.outOfRange then
-		hotkey:SetVertexColor(unpack(self.config.colors.range))
-	  else
-		hotkey:SetVertexColor(unpack(self.config.colors.usable))
-	  end
+	if force or (oldRange ~= self.outOfRange) then
+		if self.config.outOfRangeColoring == "button" then
+			UpdateUsable(self)
+		elseif self.config.outOfRangeColoring == "hotkey" then
+			local hotkey = self.hotkey
+			if self.outOfRange then
+				hotkey:SetVertexColor(unpack(self.config.colors.range))
+			else
+				hotkey:SetVertexColor(unpack(self.config.colors.usable))
+			end
+		end
 	end
-  end
 end
 
 -----------------------------------------------------------
@@ -1137,25 +1137,25 @@ function UpdateTooltip(self)
 end
 
 function UpdateHotkeys(self)
-  local key = self:GetHotkey()
-  if not key or key == "" or self.config.hideElements.hotkey then
-	self.hotkey:SetText(RANGE_INDICATOR)
-	self.hotkey:SetPoint("TOPRIGHT", 0, -3);
-	local inRange = self:IsInRange()
-	if inRange ~= nil then
-	  self.hotkey:Show();
+	local key = self:GetHotkey()
+	if not key or key == "" or self.config.hideElements.hotkey then
+		self.hotkey:SetText(RANGE_INDICATOR)
+		self.hotkey:SetPoint("TOPRIGHT", 0, -3);
+		local inRange = self:IsInRange()
+		if inRange ~= nil then
+			self.hotkey:Show();
+		else
+			self.hotkey:Hide()
+		end
 	else
-	  self.hotkey:Hide()
+		self.hotkey:SetText(key)
+		self.hotkey:SetPoint("TOPRIGHT", 0, -3);
+		self.hotkey:Show()
 	end
-  else
-	self.hotkey:SetText(key)
-	self.hotkey:SetPoint("TOPRIGHT", 0, -3);
-	self.hotkey:Show()
-  end
 
-  if self.postKeybind then
-	self.postKeybind(nil, self)
-  end
+	if self.postKeybind then
+		self.postKeybind(nil, self)
+	end
 end
 
 function UpdateRangeTimer()

--- a/ElvUI/Modules/ActionBars/ActionBars.lua
+++ b/ElvUI/Modules/ActionBars/ActionBars.lua
@@ -569,6 +569,11 @@ function AB:StyleButton(button, noBackdrop, useMasque)
 		end
 	end
 
+	local text = hotkey:GetText()
+	if text == RANGE_INDICATOR then
+		hotkey:FontTemplate(LSM:Fetch("font", "Fonts\NIM_____.ttf"), hotkey.fontSize, hotkey.fontStyle)
+	end
+
 	self:FixKeybindText(button)
 
 	if not button.useMasque then


### PR DESCRIPTION
- added check for offensive spells to avoid hiding behavior
- forcibly applied the font to buttons without keybind so that the distance indicators are displayed correctly

before: https://www.screencast.com/t/ncMw5c8McP4I
after: https://www.screencast.com/t/cHV4ht2jndi