### PR TITLE
Implement a check of the druid formName instead of ID of the form

### DIFF
--- a/ElvUI/Modules/UnitFrames/Elements/ComboPoints.lua
+++ b/ElvUI/Modules/UnitFrames/Elements/ComboPoints.lua
@@ -259,8 +259,9 @@ function UF:UpdateComboDisplay(event, unit)
 
 	if db.combobar.enable then
 		local inVehicle = UnitHasVehicleUI("player") or UnitHasVehicleUI("vehicle")
-		local _, formName = GetShapeshiftFormInfo(GetShapeshiftForm())
-		if not inVehicle and E.myclass ~= "ROGUE" and (E.myclass ~= "DRUID" or (E.myclass == "DRUID" and formName ~= "Cat Form")) then
+		local _, formName = GetShapeshiftFormInfo(GetShapeshiftForm()) --Get the name of the current form
+		local catFormName = GetSpellInfo(768) --Cat Form spell name for localization purposes
+		if not inVehicle and E.myclass ~= "ROGUE" and (E.myclass ~= "DRUID" or (E.myclass == "DRUID" and formName ~= catFormName)) then
 			element:Hide()
 			UF.ToggleResourceBar(element)
 		else

--- a/ElvUI/Modules/UnitFrames/Elements/ComboPoints.lua
+++ b/ElvUI/Modules/UnitFrames/Elements/ComboPoints.lua
@@ -259,8 +259,8 @@ function UF:UpdateComboDisplay(event, unit)
 
 	if db.combobar.enable then
 		local inVehicle = UnitHasVehicleUI("player") or UnitHasVehicleUI("vehicle")
-
-		if not inVehicle and E.myclass ~= "ROGUE" and (E.myclass ~= "DRUID" or (E.myclass == "DRUID" and GetShapeshiftForm() ~= 3)) then
+		local _, formName = GetShapeshiftFormInfo(GetShapeshiftForm())
+		if not inVehicle and E.myclass ~= "ROGUE" and (E.myclass ~= "DRUID" or (E.myclass == "DRUID" and formName ~= "Cat Form")) then
 			element:Hide()
 			UF.ToggleResourceBar(element)
 		else


### PR DESCRIPTION
Sometimes a server can return ID of 2 instead of ID of 3 for a "Cat Form", Not sure why, maybe if you train cat form before Aquatic Form ? So in order to make sure this is bulletproof there should be a check for the formName instead of an ID 